### PR TITLE
docs(api): mailbox description improved

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -988,7 +988,10 @@ paths:
         - Mailboxes
       description: >-
         You may create your own mailbox using this action. It takes a JSON
-        object containing a domain informations.
+        object containing a mailbox information.
+
+        Passwords can either be clear text or hashed passwords. For supported 
+        hash algorithms please refer to the documentation.
       operationId: Create mailbox
       requestBody:
         content:


### PR DESCRIPTION
It wasn't clear that hashes are supported. Examples in swaggerUI only show clear text. Only a hint in the telegram group made me aware about it. It's really good and important to know for migrations from other systems.

Btw. not sure if this is the correct and only place to change it. Please cascade to other repos if needed.